### PR TITLE
Add OpenCV local build to arm32 DockerFiles

### DIFF
--- a/modules/CameraCapture/arm32v7.Dockerfile
+++ b/modules/CameraCapture/arm32v7.Dockerfile
@@ -53,18 +53,6 @@ RUN  OPENCV_VERSION=3.4.2 \
     .. \
   && make \
   && sudo make install \
-  # verify the installation is successful
-  && python -c "import cv2; print('Installed OpenCV version is: {} :)'.format(cv2.__version__))" \
-  && if [ $? -eq 0 ]; then \
-      echo "OpenCV installed successfully! ........................."; \
-  else \
-      echo "OpenCV installation failed :( ........................." \
-      && SITE_PACKAGES_DIR=/usr/local/lib/python2.7/site-packages \
-      && echo "$SITE_PACKAGES_DIR contents: " \
-      && echo `ls -ltrh $SITE_PACKAGES_DIR` \
-      && echo "Note: temporary installation dir $WS_DIR/opencv is not removed!" \
-      && exit 1; \
-  fi \
   # cleanup
   && cd $WS_DIR \
   && sudo rm -rf opencv

--- a/modules/CameraCapture/arm32v7.Dockerfile
+++ b/modules/CameraCapture/arm32v7.Dockerfile
@@ -1,6 +1,5 @@
-FROM mohaseeb/raspberrypi3-python-opencv:latest
-#This image is base on the resin image which is based on armv7 debian jessie, which has libboost-python1.55.0.
-#This image include a pre-compiled version of OpenCV. It is based on python 2.7.
+FROM resin/raspberrypi3-python:2.7
+#This image is base on the resin image for building Python apps on Raspberry Pi 3.
 
 #Enforces cross-compilation through Quemu
 RUN [ "cross-build-start" ]
@@ -9,14 +8,66 @@ RUN [ "cross-build-start" ]
 RUN apt-get update
 
 #Needed by iothub_client
-RUN apt-get install -y \
-        libboost-python1.55.0
+RUN apt-get install -y libboost-python1.55.0
 
 #Install python packages        
 COPY /build/arm32v7-requirements.txt ./
-RUN pip install --upgrade pip 
-RUN pip install --upgrade setuptools 
-RUN pip install -r arm32v7-requirements.txt
+RUN pip install --upgrade pip  && pip install --upgrade setuptools && pip install -r arm32v7-requirements.txt
+
+# Install build modules for 
+# Based on the work at https://github.com/mohaseeb/raspberrypi3-opencv-docker
+RUN sudo apt-get install -y --no-install-recommends \
+    # to build and install opencv
+    unzip \
+    build-essential cmake pkg-config \
+    # to work with image files
+    libjpeg-dev libtiff5-dev libjasper-dev libpng-dev \
+    # to work with video files
+    libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+    # to display GUI
+    libgtk2.0-dev pkg-config \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && sudo apt-get -y autoremove
+
+RUN  OPENCV_VERSION=3.4.2 \
+  && WS_DIR=`pwd` \
+  && mkdir opencv \
+  && cd opencv \
+  # download OpenCV and opencv_contrib
+  && wget -O opencv.zip https://github.com/opencv/opencv/archive/$OPENCV_VERSION.zip \
+  && unzip opencv.zip \
+  && sudo rm -rf opencv.zip \
+  && OPENCV_SRC_DIR=`pwd`/opencv-$OPENCV_VERSION \
+  # build and install without gpu dependency
+  && cd $OPENCV_SRC_DIR \
+  && mkdir build && cd build \
+  && cmake -D CMAKE_BUILD_TYPE=RELEASE \
+    -D CMAKE_INSTALL_PREFIX=/usr/local \
+    -D ENABLE_FAST_MATH=1 \
+    -D CUDA_FAST_MATH=1 \
+    -D WITH_OPENCL=off -D WITH_OPENCL_SVM=off \
+    -D WITH_OPENCLAMDFFT=off \
+    -D WITH_OPENCLAMDBLAS=off \
+    -D OPENCV_EXTRA_MODULES_PATH=$OPENCV_CONTRIB_MODULES_SRC_DIR \
+    -D BUILD_opencv_gpu=off \
+    .. \
+  && make \
+  && sudo make install \
+  # verify the installation is successful
+  && python -c "import cv2; print('Installed OpenCV version is: {} :)'.format(cv2.__version__))" \
+  && if [ $? -eq 0 ]; then \
+      echo "OpenCV installed successfully! ........................."; \
+  else \
+      echo "OpenCV installation failed :( ........................." \
+      && SITE_PACKAGES_DIR=/usr/local/lib/python2.7/site-packages \
+      && echo "$SITE_PACKAGES_DIR contents: " \
+      && echo `ls -ltrh $SITE_PACKAGES_DIR` \
+      && echo "Note: temporary installation dir $WS_DIR/opencv is not removed!" \
+      && exit 1; \
+  fi \
+  # cleanup
+  && cd $WS_DIR \
+  && sudo rm -rf opencv
 
 RUN [ "cross-build-end" ]  
 

--- a/modules/CameraCapture/test-arm32v7.Dockerfile
+++ b/modules/CameraCapture/test-arm32v7.Dockerfile
@@ -1,6 +1,5 @@
-FROM mohaseeb/raspberrypi3-python-opencv:latest
-#This image is base on the resin image which is based on armv7 debian jessie, which has libboost-python1.55.0.
-#This image include a pre-compiled version of OpenCV. It is based on python 2.7.
+FROM resin/raspberrypi3-python:2.7
+#This image is base on the resin image for building Python apps on Raspberry Pi 3.
 
 #Enforces cross-compilation through Quemu
 RUN [ "cross-build-start" ]
@@ -8,21 +7,72 @@ RUN [ "cross-build-start" ]
 #update list of packages available
 RUN apt-get update
 
-#Needed to use iothub_client.so. iothub_client is manually compiled until an ARM version can be installed through pip install
-RUN apt-get install -y \
-        libboost-python1.55.0
+#Needed by iothub_client
+RUN apt-get install -y libboost-python1.55.0
 
 #Install python packages        
 COPY /build/arm32v7-requirements.txt ./
-RUN pip install --upgrade pip 
-RUN pip install --upgrade setuptools 
-RUN pip install -r arm32v7-requirements.txt
+RUN pip install --upgrade pip  && pip install --upgrade setuptools && pip install -r arm32v7-requirements.txt
+
+# Install build modules for openCV
+# Based on the work at https://github.com/mohaseeb/raspberrypi3-opencv-docker
+RUN sudo apt-get install -y --no-install-recommends \
+    # to build and install opencv
+    unzip \
+    build-essential cmake pkg-config \
+    # to work with image files
+    libjpeg-dev libtiff5-dev libjasper-dev libpng-dev \
+    # to work with video files
+    libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+    # to display GUI
+    libgtk2.0-dev pkg-config \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && sudo apt-get -y autoremove
+
+RUN  OPENCV_VERSION=3.4.2 \
+  && WS_DIR=`pwd` \
+  && mkdir opencv \
+  && cd opencv \
+  # download OpenCV and opencv_contrib
+  && wget -O opencv.zip https://github.com/opencv/opencv/archive/$OPENCV_VERSION.zip \
+  && unzip opencv.zip \
+  && sudo rm -rf opencv.zip \
+  && OPENCV_SRC_DIR=`pwd`/opencv-$OPENCV_VERSION \
+  # build and install without gpu dependency
+  && cd $OPENCV_SRC_DIR \
+  && mkdir build && cd build \
+  && cmake -D CMAKE_BUILD_TYPE=RELEASE \
+    -D CMAKE_INSTALL_PREFIX=/usr/local \
+    -D ENABLE_FAST_MATH=1 \
+    -D CUDA_FAST_MATH=1 \
+    -D WITH_OPENCL=off -D WITH_OPENCL_SVM=off \
+    -D WITH_OPENCLAMDFFT=off \
+    -D WITH_OPENCLAMDBLAS=off \
+    -D OPENCV_EXTRA_MODULES_PATH=$OPENCV_CONTRIB_MODULES_SRC_DIR \
+    -D BUILD_opencv_gpu=off \
+    .. \
+  && make \
+  && sudo make install \
+  # verify the installation is successful
+  && python -c "import cv2; print('Installed OpenCV version is: {} :)'.format(cv2.__version__))" \
+  && if [ $? -eq 0 ]; then \
+      echo "OpenCV installed successfully! ........................."; \
+  else \
+      echo "OpenCV installation failed :( ........................." \
+      && SITE_PACKAGES_DIR=/usr/local/lib/python2.7/site-packages \
+      && echo "$SITE_PACKAGES_DIR contents: " \
+      && echo `ls -ltrh $SITE_PACKAGES_DIR` \
+      && echo "Note: temporary installation dir $WS_DIR/opencv is not removed!" \
+      && exit 1; \
+  fi \
+  # cleanup
+  && cd $WS_DIR \
+  && sudo rm -rf opencv
 
 RUN [ "cross-build-end" ]  
 
 ADD /app/ .
 ADD /build/ . 
-ADD /test/ .
+ADD /test/ . 
 
-#Manually run the IntegrationTests.py or test other functions
-ENTRYPOINT ["bash"]
+ENTRYPOINT [ "bash" ]

--- a/modules/CameraCapture/test-arm32v7.Dockerfile
+++ b/modules/CameraCapture/test-arm32v7.Dockerfile
@@ -53,18 +53,6 @@ RUN  OPENCV_VERSION=3.4.2 \
     .. \
   && make \
   && sudo make install \
-  # verify the installation is successful
-  && python -c "import cv2; print('Installed OpenCV version is: {} :)'.format(cv2.__version__))" \
-  && if [ $? -eq 0 ]; then \
-      echo "OpenCV installed successfully! ........................."; \
-  else \
-      echo "OpenCV installation failed :( ........................." \
-      && SITE_PACKAGES_DIR=/usr/local/lib/python2.7/site-packages \
-      && echo "$SITE_PACKAGES_DIR contents: " \
-      && echo `ls -ltrh $SITE_PACKAGES_DIR` \
-      && echo "Note: temporary installation dir $WS_DIR/opencv is not removed!" \
-      && exit 1; \
-  fi \
   # cleanup
   && cd $WS_DIR \
   && sudo rm -rf opencv


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Update ARM32 DockerFiles to build OpenCV directly instead of relying on a third party’s build of OpenCV.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Just run the containers as you would before.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Credit: The update is based on the work at https://github.com/mohaseeb/raspberrypi3-opencv-docker 
