### PR TITLE
Add support for remote websocket

### DIFF
--- a/modules/CameraCapture/app/templates/index.html
+++ b/modules/CameraCapture/app/templates/index.html
@@ -8,7 +8,7 @@
     <script>
 
       var img = document.getElementById("currentImage");
-      var ws = new WebSocket("ws://localhost:5012/stream");
+      var ws = new WebSocket("ws://" + location.host + "/stream");
 
       ws.onopen = function() {
           console.log("connection was established");


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Adds the ability to see the stream from a remote computer.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/jmservera/Custom-vision-service-iot-edge-raspberry-pi
cd Custom-vision-service-iot-edge-raspberry-pi/modules/CameraCapture
docker build . -f arm32v7.Dockerfile
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Open a browser to the http://[yourdevicename]:5012 address and check that the video shows up. If it does not show the video, try with the device IP instead

## Other Information
Microsoft Edge usually works with local names like http://raspberrypi.local:5012, but in Firefox or Chrome, even when page usually opens with the NetBIOS name, sometimes websockets do not work. If this happens use local IP address instead and try again.