### PR TITLE
SenseHat Module not building

### DIFF
--- a/deployment.template.json
+++ b/deployment.template.json
@@ -75,7 +75,7 @@
               "THRESHOLD": {"value": 0.6}
             },
             "settings": {
-              "image": "${MODULES.SenseHatDisplay}",
+              "image": "${MODULES.SenseHatDisplay.arm32v7}",
               "createOptions": {
                 "HostConfig":{
                   "Binds":["/dev/i2c1:/dev/i2c1"],


### PR DESCRIPTION
The SenseHat Display Module doesn't build because it is doesn't target the architecture for the Dockerfile. 

To repeat:
1. Clone repo 
2. Right click deployment.template.json and choose Build and Push IoT Edge Solution
3. Only Camera Capture and Image Classifier modules are built and pushed.

Resolution:
Add the architecture (.arm32v7) to the senshat-display module image settings.
Alternatively, rename the Dockerfile in the SenseHat module folder, but including the architecture seems neater overall.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->