### PR TITLE
Read placeholder size from graph

### DIFF
--- a/modules/ImageClassifierService/app/predict.py
+++ b/modules/ImageClassifierService/app/predict.py
@@ -25,9 +25,12 @@ labels = []
 
 def initialize():
     print('Loading model...',end=''),
-    with tf.gfile.FastGFile(filename, 'rb') as f:
+    with tf.gfile.GFile(filename, 'rb') as f:
         graph_def.ParseFromString(f.read())
         tf.import_graph_def(graph_def, name='')
+        input_tensor = tf.get_default_graph().get_tensor_by_name("Placeholder:0")
+        network_input_size = int(input_tensor.get_shape()[1])
+        print("Adjusted network input size to " + str(network_input_size))
     print('Success!')
     print('Loading labels...', end='')
     with open(labels_filename, 'rt') as lf:

--- a/modules/ImageClassifierService/app/predict.py
+++ b/modules/ImageClassifierService/app/predict.py
@@ -13,7 +13,6 @@ import os
 filename = 'model.pb'
 labels_filename = 'labels.txt'
 
-network_input_size = 227
 mean_values_b_g_r = (0,0,0)
 
 size = (256, 256)
@@ -28,9 +27,6 @@ def initialize():
     with tf.gfile.GFile(filename, 'rb') as f:
         graph_def.ParseFromString(f.read())
         tf.import_graph_def(graph_def, name='')
-        input_tensor = tf.get_default_graph().get_tensor_by_name("Placeholder:0")
-        network_input_size = int(input_tensor.get_shape()[1])
-        print("Adjusted network input size to " + str(network_input_size))
     print('Success!')
     print('Loading labels...', end='')
     with open(labels_filename, 'rt') as lf:
@@ -60,6 +56,9 @@ def predict_image(image):
     
     with tf.Session() as sess:
         prob_tensor = sess.graph.get_tensor_by_name(output_layer)
+
+        input_tensor_shape = sess.graph.get_tensor_by_name('Placeholder:0').shape.as_list()
+        network_input_size = input_tensor_shape[1]
 
         # w = image.shape[0]
         # h = image.shape[1]

--- a/modules/ImageClassifierService/app/predict.py
+++ b/modules/ImageClassifierService/app/predict.py
@@ -24,7 +24,7 @@ labels = []
 
 def initialize():
     print('Loading model...',end=''),
-    with tf.gfile.GFile(filename, 'rb') as f:
+    with tf.gfile.FastGFile(filename, 'rb') as f:
         graph_def.ParseFromString(f.read())
         tf.import_graph_def(graph_def, name='')
     print('Success!')


### PR DESCRIPTION
## Purpose
Fixed issue #39 - the Custom Vision exported model has a changed input size. According to other samples it is now expected that the input size is read from the graph rather than hardcoded at 227.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Train and export new custom vision model. Previously would not work, now does.
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->