### PR TITLE
Change tf import to support Tensorflow 2.0.0

### DIFF
--- a/modules/ImageClassifierService/app/predict.py
+++ b/modules/ImageClassifierService/app/predict.py
@@ -1,7 +1,7 @@
 
 from urllib.request import urlopen
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from PIL import Image
 import numpy as np


### PR DESCRIPTION
## Purpose
The `tensorflow:latest-py3` [container uses TensorFlow 2.0.0](https://hub.docker.com/layers/tensorflow/tensorflow/latest-py3/images/sha256-0b236338fac6c3361cf3ae1448f8c053994e260c1edc4fa63ed80adb3045abb2) which does not support `GraphDef()`. This causes the Image Classifier Service container to fail. Changing the import function to `tensorflow.compat.v1` maintains support for TensorFlow <2.0.0 functionality and the container (and the solution) start successfully.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Clone the original repo
* Populate the `.env` file with Azure Container Registry information
* Build and Push the IoT Edge solution containers
* Deploy the solution from the config JSON
* Monitor the containers on the IoT Edge device
* The `image-classifier-service` container will fail on `predict.py`
* Error is "module 'tensorflow' has no attribute 'GraphDef'

## Other Information
There is a [published article](https://www.tensorflow.org/guide/migrate) on migrating Tensorflow 1 code to Tensorflow 2. I have not included this in this PR, as the aim was just to get the original solution functional.