### PR TITLE
Fix bugs 66 and 67: missing package libxcb for latest PIL package in sense-hat and image-classifier container

### DIFF
--- a/modules/ImageClassifierService/arm32v7.Dockerfile
+++ b/modules/ImageClassifierService/arm32v7.Dockerfile
@@ -2,10 +2,10 @@ FROM balenalib/raspberrypi3-debian-python:3.7
 
 RUN [ "cross-build-start" ]
 
-RUN apt update && apt install -y libjpeg62-turbo libopenjp2-7 libtiff5 libatlas-base-dev
+RUN apt update && apt install -y libjpeg62-turbo libopenjp2-7 libtiff5 libatlas-base-dev libxcb1
 RUN pip install absl-py six protobuf wrapt gast astor termcolor keras_applications keras_preprocessing --no-deps
 RUN pip install numpy==1.16 tensorflow==1.13.1 --extra-index-url 'https://www.piwheels.org/simple' --no-deps
-RUN pip install flask pillow --index-url 'https://www.piwheels.org/simple'
+RUN pip install flask==1.1.2 pillow==7.1.2 --index-url 'https://www.piwheels.org/simple'
 
 COPY app /app
 

--- a/modules/ImageClassifierService/module.json
+++ b/modules/ImageClassifierService/module.json
@@ -4,7 +4,7 @@
     "image": {
         "repository": "$CONTAINER_REGISTRY_ADDRESS/imageclassifierservice",
         "tag": {
-            "version": "0.2.16",
+            "version": "0.2.17",
             "platforms": {
                 "amd64": "./amd64.Dockerfile",
                 "arm32v7": "./arm32v7.Dockerfile"

--- a/modules/SenseHatDisplay/arm32v7.Dockerfile
+++ b/modules/SenseHatDisplay/arm32v7.Dockerfile
@@ -29,7 +29,8 @@ RUN install_packages \
     libatlas-base-dev \
     libopenjp2-7 \
     libtiff-tools \
-    i2c-tools
+    i2c-tools \
+    libxcb1
 
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/* \

--- a/modules/SenseHatDisplay/build/arm32v7-requirements.txt
+++ b/modules/SenseHatDisplay/build/arm32v7-requirements.txt
@@ -1,4 +1,4 @@
 azure-iothub-device-client
-numpy
+numpy=1.18.3
 rtimulib
-sense-hat
+sense-hat=2.2.0

--- a/modules/SenseHatDisplay/build/arm32v7-requirements.txt
+++ b/modules/SenseHatDisplay/build/arm32v7-requirements.txt
@@ -1,4 +1,4 @@
 azure-iothub-device-client
-numpy=1.18.3
+numpy==1.18.3
 rtimulib
-sense-hat=2.2.0
+sense-hat==2.2.0

--- a/modules/SenseHatDisplay/module.json
+++ b/modules/SenseHatDisplay/module.json
@@ -4,7 +4,7 @@
     "image": {
         "repository": "$CONTAINER_REGISTRY_ADDRESS/sensehatdisplay",
         "tag": {
-            "version": "0.2.13",
+            "version": "0.2.14",
             "platforms": {
                 "arm32v7": "./arm32v7.Dockerfile",
                 "test-arm32v7": "./test/test-arm32v7.Dockerfile"


### PR DESCRIPTION
## Purpose
Fix bugs 66 and 67: Containers sense-hat and image-classifier were no longer running because they were missing package libxcb. This package is a new dependency coming from the latest PIL package. To remediate these issues, package libxcb have been added to both containers. TO prevent further issues, PIL and numpy package versions have been frozen.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Follow the instructions to get the code, compile the containers, deploy them to a raspberry pi.
Show a banana then an apple in front of the camera and verify that the senseHat display blinks accordingly.